### PR TITLE
Add dependencies for Ubuntu 22.04 on WSL2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,9 @@ if [ "$distro_name" = "Ubuntu" ]; then
      sudo apt update
      sudo DEBIAN_FRONTEND=noninteractive apt install -y \
           tesseract-ocr \
-          ghostscript
+          ghostscript \
+          poppler-utils \
+          bc
 fi
 
 echo ""


### PR DESCRIPTION
Ubuntu 22.04 on WSL2 does not come preinstalled with `pdftoppm`, which causes the script to fail, therefore I added `poppler-utils` which provides it. It also does not come with `bc`; however this does not cause the script to fail, but display "command not found" at the end. I included it to enable full functionality of the script.